### PR TITLE
Specs core layout helper

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -61,10 +61,11 @@ module Decidim
       end
     end
 
+    # Allows to create role attribute according to accessibility rules
+    #
+    # Returns role attribute string if role option is specified
     def role(options = {})
-      return "role=#{options[:role]}" if options[:role]
-
-      ""
+      "role=\"#{options[:role]}\" " if options[:role]
     end
 
     def _icon_classes(options = {})

--- a/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
@@ -30,6 +30,30 @@ module Decidim
             </svg>
           SVG
         end
+
+        context "with role attribute specified" do
+          it "implements role attribute" do
+            result = helper.component_icon(component, role: "img")
+            expect(result).to eq <<~SVG
+              <svg class="icon external-icon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36.02 36.02">
+                <circle cx="18.01" cy="18.01" r="15.75" stroke="#2ecc71" stroke-width="4" fill="none"></circle>
+                <circle cx="18.01" cy="18.01" r="11.25" stroke="#08BCD0" stroke-width="4" fill="none" />
+              </svg>
+            SVG
+          end
+        end
+
+        context "with no role attribute specified" do
+          it "doesn't implement role attribute" do
+            result = helper.component_icon(component)
+            expect(result).to eq <<~SVG
+              <svg class="icon external-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36.02 36.02">
+                <circle cx="18.01" cy="18.01" r="15.75" stroke="#2ecc71" stroke-width="4" fill="none"></circle>
+                <circle cx="18.01" cy="18.01" r="11.25" stroke="#08BCD0" stroke-width="4" fill="none" />
+              </svg>
+            SVG
+          end
+        end
       end
 
       describe "resource_icon" do


### PR DESCRIPTION
#### :tophat: What? Why?

Adds a way to inject role attribute in layout helper according to accessibility rules

#### :clipboard: Subtasks
- [x] Add comments on role function
- [x] Light refactor of role function
- [x] Add tests