### PR TITLE
Fix capybara window height

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -270,6 +270,7 @@ module Decidim
 
       initializer "Expire sessions" do
         Rails.application.config.session_store :active_record_store, key: "_decidim_session", expire_after: Decidim.config.expire_session_after
+        ActiveRecord::SessionStore::Session.serializer = :hybrid
       end
 
       initializer "decidim.core.register_resources" do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -23,7 +23,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless"
   options.args << "--no-sandbox"
-  options.args << "--window-size=1024,768"
+  options.args << "--window-size=1024,1024"
 
   Capybara::Selenium::Driver.new(
     app,

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -335,7 +335,7 @@ describe "Initiative", type: :system do
 
           it "Offers contextual help" do
             within ".callout.success" do
-              expect(page).to have_content("Congratulations! Your citizen initiative has been successfully created.")
+              expect(page).to have_content("Congratulations! Your initiative has been successfully created.")
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Unique test fails in initiatives filters because of window height configuration


