### PR TITLE
Backport "send an initiative to technical validation after it was discarded"

### DIFF
--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -206,10 +206,11 @@ module Decidim
         end
 
         def allowed_to_send_to_technical_validation?
-          initiative.created? && (
-            !initiative.created_by_individual? ||
-            initiative.enough_committee_members?
-          )
+          initiative.discarded? ||
+            (initiative.created? && (
+              !initiative.created_by_individual? ||
+              initiative.enough_committee_members?
+            ))
         end
       end
     end

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -223,7 +223,7 @@ en:
           edit:
             accept: Accept initiative
             confirm: Are you sure?
-            confirm_send_to_technical_validation: You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?
+            confirm_send_to_technical_validation: Are you sure?
             discard: Discard the initiative
             export_pdf_signatures: Export PDF of signatures
             export_votes: Export signatures

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
@@ -179,10 +179,6 @@ describe Decidim::Initiatives::Admin::Permissions do
       context "when sending to technical validation" do
         let(:action_name) { :send_to_technical_validation }
 
-        context "when initiative is not created" do
-          it { is_expected.to eq false }
-        end
-
         context "when initiative is created" do
           let(:initiative) { create :initiative, :created, organization: organization }
 
@@ -211,6 +207,16 @@ describe Decidim::Initiatives::Admin::Permissions do
 
             it { is_expected.to eq false }
           end
+        end
+
+        context "when initiative is discarded" do
+          let(:initiative) { create :initiative, :discarded, organization: organization }
+
+          it { is_expected.to eq true }
+        end
+
+        context "when initiative is not created or discarded" do
+          it { is_expected.to eq false }
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport PR 6993 : Allow the admin to send an initiative to technical validation after it was discarded 
