### PR TITLE
[TEST CI] Remove required fields message in "Start a UserGroup conversation"

### DIFF
--- a/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
@@ -6,8 +6,6 @@
   </h5>
 
   <%= form_for form, url: decidim.conversations_path, remote: true do |f| %>
-    <%= form_required_explanation %>
-
     <% @form.recipient.each do |recipient| %>
       <%= f.hidden_field :recipient_id, id: nil, name: "conversation[recipient_id][]", value: recipient.id %>
     <% end %>

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -28,11 +28,13 @@ describe "Conversations", type: :system do
 
   shared_examples "create new conversation" do
     it "allows sending an initial message", :slow do
+      expect(page).not_to have_content("Required fields are marked with an asterisk")
       start_conversation("Is this a Ryanair style democracy?")
       expect(page).to have_selector(".conversation-chat:last-child", text: "Is this a Ryanair style democracy?")
     end
 
     it "redirects to an existing conversation if it exists already", :slow do
+      expect(page).not_to have_content("Required fields are marked with an asterisk")
       start_conversation("Is this a Ryanair style democracy?")
       expect(page).to have_selector(".conversation-chat:last-child", text: "Is this a Ryanair style democracy?")
 


### PR DESCRIPTION
#### :tophat: What? Why?

Remove form explanation in fields message in "Start a UserGroup conversation"

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
### :camera: Screenshots (optional)
![start_conversation](https://user-images.githubusercontent.com/26109239/112669012-77549000-8e5f-11eb-97ad-236462382d19.png)
