### PR TITLE
Light refactor of duplicated Active Record admins queries

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
@@ -101,12 +101,8 @@ module Decidim
           event: "decidim.events.initiatives.support_threshold_reached",
           event_class: Decidim::Initiatives::Admin::SupportThresholdReachedEvent,
           resource: initiative,
-          followers: organization_admins
+          followers: initiative.organization.admins
         )
-      end
-
-      def organization_admins
-        Decidim::User.where(organization: initiative.organization, admin: true)
       end
     end
   end

--- a/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
@@ -40,7 +40,7 @@ module Decidim
           event: "decidim.events.verifications.managed_user_error_event",
           event_class: Decidim::Verifications::ManagedUserErrorEvent,
           resource: conflict,
-          affected_users: Decidim::User.where(admin: true, organization: @organization)
+          affected_users: @organization.admins
         )
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Suggestion of a light refactor to use the `admins` relation defined in organization's model, where admins are fetched using an Active record query.

Requests are exactly the same but may be easier to read

#### :pushpin: Related Issues
No related issue

